### PR TITLE
Support amazon platform family for chef14

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer_email 'maciej@3ofcoins.net'
 license          'MIT'
 description      'Configures hostname and FQDN'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.2'
+version          '0.4.3'
 
 supports 'debian'
 supports 'ubuntu'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -59,7 +59,7 @@ if fqdn
       notifies :reload, 'ohai[reload_hostname]', :immediately
     end
 
-  when 'rhel'
+  when 'rhel', 'amazon'
     service 'network' do
       action :nothing
     end


### PR DESCRIPTION
updates for /etc/sysconfig/network /etc/sysctl.conf were skipped bc of missing platform_family check in there.